### PR TITLE
Add cell on python math

### DIFF
--- a/computational-nuclear-activity.ipynb
+++ b/computational-nuclear-activity.ipynb
@@ -65,7 +65,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "a = 3   # my variable is a and it is equal to 3"
@@ -79,13 +81,15 @@
     "\n",
     "In this last cell we've also *defined our first variable*. Here we've set the variable `a` equal to the number 3. We can call that variable again in the future by putting it in a cell and executing it again. \n",
     "\n",
-    "You may also see some teal text following a `#` character. This is how we comment code in Python. Any content on a line that comes after a hashtag symbol is interpreted as a comment and is not interpreted by the computer. This is helpful when we write code to remind ourselves of what our code is doing, especially in complicated places where lots of stuff might be going on. "
+    "You may also see some teal text following a `#` character. This is how we comment code in Python. Any content on a line that comes after a pound or hash symbol is interpreted as a comment and is not interpreted by the computer. This is helpful when we write code to remind ourselves of what our code is doing, especially in complicated places where lots of stuff might be going on. "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "a"
@@ -103,7 +107,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "a*6 "
@@ -112,7 +118,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "a*12/333"
@@ -121,10 +129,34 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "(a+a+2+9)*22/10000"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "For reference, the following symbols can be used to do basic mathematical operations in Python\n",
+    "\n",
+    "* \\* is used for multiplication, e.g. $a \\times b$\n",
+    "* \\+ is used for addition, e.g. $a + b$ \n",
+    "* \\- is used for subtraction, e.g. $a - b$\n",
+    "* \\\\ is used for division, e.g. $\\frac{a}{b}$ \n",
+    "* \\*\\* is used for exponents, e.g. $a^b$. You may also find it helpful to use scientific notation to express large numbers. For example $10^2$ is the same as $10e2$ and Python will automatically recognize scientific notation as a number. \n",
+    "\n",
+    "There are many mathematical operations available in the Python core library. [Here](https://en.wikibooks.org/wiki/Python_Programming/Basic_Math#Mathematical_Operators) and [here](https://docs.python.org/2/library/math.html) are references if you'd like to see what else is available. \n",
+    "\n",
+    "This lesson will also require a few functions from the `math` module in Python. Those are:\n",
+    "\n",
+    "* math.exp() for exponents, e.g. $e^2$\n",
+    "* math.log() for natural log, e.g. $\\ln(100)$\n",
+    "* math.pi for the constant $\\pi$"
    ]
   },
   {
@@ -137,7 +169,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def multiply_three_numbers(a, b, c):\n",
@@ -170,7 +204,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "multiply_three_numbers?"
@@ -192,7 +228,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "multiply_three_numbers(3,8,33)"
@@ -253,7 +291,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# First we need to import a python math library\n",
@@ -270,15 +310,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# This function calculates the activity of a radionuclide\n",
-    "\n",
-    "# input: decay constant for a radionuclide [1/seconds], initial concentration of atoms, time [seconds]\n",
-    "# output: activity [particles/second]\n",
-    "\n",
     "def calculate_activity_with_time(nuclide_decay_constant, initial_concentration, time):\n",
+    "    \"\"\"\n",
+    "    This function calculates the activity of a radionuclide\n",
+    "    \n",
+    "    input: decay constant for a radionuclide [1/seconds], initial concentration of atoms, time [seconds]\n",
+    "    output: activity [particles/second]\n",
+    "    \"\"\"\n",
     "    return activity"
    ]
   },
@@ -291,8 +334,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Test your function here\n",
@@ -334,19 +379,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# This function calculates the total number of particles hitting a body at distance \n",
-    "# `distance_from_source` away from the source.\n",
-    "\n",
-    "# Assumptions:\n",
-    "# The area of a human body can be calculated as height*width.\n",
-    "\n",
-    "# input: distance_from_source [cm], body_surface_area [cm^2], initial concentration of atoms. \n",
-    "# output: ???\n",
-    "\n",
     "def calculate_particles_with_distance(distance_from_source, body_surface_area, initial_concentration):\n",
+    "    \"\"\"\n",
+    "    This function calculates the total number of particles hitting a body at distance \n",
+    "    `distance_from_source` away from the source.\n",
+    "\n",
+    "    Assumptions:\n",
+    "    The area of a human body can be calculated as height*width.\n",
+    "\n",
+    "    input: distance_from_source [cm], body_surface_area [cm^2], initial concentration of atoms. \n",
+    "    output: ???\n",
+    "    \"\"\"\n",
     "    return"
    ]
   },
@@ -359,8 +407,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Test your function here\n",
@@ -417,16 +467,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# This function calculates the change in particle rate given a shield of a specific thickness. \n",
     "# Fill out the input and output fields in the comments here so others know what your code is intended to do! \n",
-    "\n",
-    "# input: ???\n",
-    "# output: ??? \n",
-    "\n",
     "def calculate_shield_attenuation():\n",
+    "    \"\"\"\n",
+    "    This function calculates the change in particle rate given a shield of a specific thickness. \n",
+    "    \n",
+    "    input: ???\n",
+    "    output: ??? \n",
+    "    \"\"\"\n",
     "    return "
    ]
   },
@@ -440,7 +493,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Test your function here\n",
@@ -489,21 +544,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# This function calculates the activity seen from a source by a shielded human \n",
-    "# after a time `elapsed_time` and a distance `distance_away`\n",
+    "# Fill out the assumptions, input and output fields in the comments here so \n",
+    "# others know what your code is intended to do! \n",
     "\n",
-    "# Fill out the assumptions, input and output fields in the comments here so others know what your code is intended to do! \n",
-    "\n",
-    "# Assumptions:\n",
-    "# ?\n",
-    "\n",
-    "# input: ???\n",
-    "# output: ???\n",
     "def calculate_activity_of_all_effects(elapsed_time, distance_away, shield_thickness, initial_concentration):\n",
+    "    \"\"\"\n",
+    "    This function calculates the activity seen from a source by a shielded human \n",
+    "    after a time `elapsed_time` and a distance `distance_away`\n",
+    "\n",
+    "    Assumptions:\n",
+    "    ?\n",
+    "\n",
+    "    input: ???\n",
+    "    output: ???\n",
+    "    \"\"\"\n",
     "    return particle_rate"
    ]
   },
@@ -516,8 +576,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Test your function here\n",
@@ -556,7 +618,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }

--- a/solutions.py
+++ b/solutions.py
@@ -7,6 +7,13 @@ import matplotlib.pyplot as plt
 
 def calculate_activity_with_time(nuclide_decay_constant,
                                  initial_concentration, time):
+    """
+    This function calculates the activity of a radionuclide
+
+    input: decay constant for a radionuclide [1/seconds], initial
+            concentration of atoms, time [seconds]
+    output: activity [particles/second]
+    """
     activity = initial_concentration * nuclide_decay_constant * math.exp(-1.0 * nuclide_decay_constant * time)
     return activity
 
@@ -16,8 +23,17 @@ def calculate_activity_with_time(nuclide_decay_constant,
 #   Objective 2 solution   #
 ############################
 
-# output: particle rate [particles/second]
 def calculate_particles_with_distance(distance_from_source, body_surface_area, initial_concentration):
+    """
+    This function calculates the total number of particles hitting a body at distance
+    `distance_from_source` away from the source.
+
+    Assumptions:
+    The area of a human body can be calculated as height*width.
+
+    input: distance_from_source [cm], body_surface_area [cm^2], initial concentration of atoms.
+    output: particle rate [particles/second]
+    """
     particle_rate = initial_concentration * body_surface_area / (4.0 * math.pi * distance_from_source * distance_from_source)
     return particle_rate
 
@@ -27,9 +43,15 @@ def calculate_particles_with_distance(distance_from_source, body_surface_area, i
 #   Objective 3 solution   #
 ############################
 
-# input: macroscopic_cross_section [1/cm], thickness [cm], initial_intensity [particles/second]
-# output: particle intensity [particles/second]
 def calculate_shield_attenuation(macroscopic_cross_section, thickness, initial_intensity):
+    """
+    This function calculates the change in particle rate given a shield of a
+    specific thickness.
+
+    input: macroscopic_cross_section [1/cm], thickness [cm], initial_intensity
+           [particles/second]
+    output: particle intensity [particles/second]
+    """
     particle_intensity = initial_intensity * math.exp(-1.0 * thickness * macroscopic_cross_section)
     return particle_intensity
 


### PR DESCRIPTION
This adds a small section in the introductory part of the lesson to include relevant python math operators, so it's clear how new learners can use them in the lesson. This is repeated a little later in the lesson inline, but I see no harm in repeating this material a few places. 

Other things:
- I cleared all of the cell outputs so now no cells should be numbered
- I updated all of the function definitions in the lesson to use docstring-style formatting, since we introduce it in the intro material anyways. 